### PR TITLE
Provided a fix for long-running timeout bug

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -238,7 +238,7 @@ Object.assign(Client.prototype, {
   },
 
   poolDefaults() {
-    return { min: 2, max: 10, propagateCreateError: true };
+    return { min: 2, max: 10, propagateCreateError: false };
   },
 
   getPoolSettings(poolConfig) {


### PR DESCRIPTION
Provide a fix for this production deployment error:
`remote: KnexTimeoutError: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?`